### PR TITLE
Add compile targets to recompile dsl to aml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,23 @@ ssdt: $(addprefix ACPI/, $(ssdt:dat=dsl)) ## no-help
 .PHONY: disassemble
 disassemble: ssdt dsdt ## Disassemble DSDT and all SSDTs
 
+compiled: ## no-help
+	mkdir compiled
+
+# Compile DSDT including external symbols found in other SSDTs
+compiled/%.aml: $(addsuffix .dsl, $(addprefix ACPI/, $(basename $@))) | compiled ## no-help
+	iasl -e $(addprefix ACPI/, $(ssdt:dat=dsl)) -p $(basename $@) $(addprefix ACPI/, $(notdir $(basename $@)).dsl)
+
+.PHONY: compile-dsdt compile-ssdt
+compile-dsdt: ACPI/$(dsdt:dat=dsl) ## no-help
+compile-ssdt: $(addprefix ACPI/, $(ssdt:dat=dsl)) $(addprefix compiled/, $(ssdt:dat=aml)) ## no-help
+
+.PHONY: compile
+compile: compile-dsdt compile-ssdt ## Compile DSDT including external symbols from all SSDTs
+
+
 .PHONY: clean
 clean:: ## Clean up generated files
 	rm -rf ./acpixtract
 	rm -rf ./ACPI
+	rm -rf ./compiled


### PR DESCRIPTION
Note: using current version of `iasl` (`20250404`), recompile does not work due to syntax errors in `ssdt7.dsl`:

<details><summary><code>ssdt7.dsl</code> syntax errors:</summary>
<p>

```console
iasl -e ACPI/ssdt1.dsl ACPI/ssdt2.dsl ACPI/ssdt3.dsl ACPI/ssdt4.dsl ACPI/ssdt5.dsl ACPI/ssdt6.dsl ACPI/ssdt7.dsl ACPI/ssdt8.dsl ACPI/ssdt9.dsl -p compiled/ssdt7 ACPI/ssdt7.dsl

Intel ACPI Component Architecture
ASL+ Optimizing Compiler/Disassembler version 20250404
Copyright (c) 2000 - 2025 Intel Corporation

Error    6126 -  Compiler aborting due to parser-detected syntax error(s)


ACPI/ssdt7.dsl     86:                                 }
Error    6126 -                          syntax error ^ 

ACPI/ssdt7.dsl    100:                             Case (0x02)
Error    6126 -                         syntax error ^ 

ACPI/ssdt7.dsl    101:                             {
Error    6126 -                      syntax error ^ 

ACPI/ssdt7.dsl    107:                                 If ((DFUD > Zero))
Error    6126 -                           syntax error ^ 

ACPI/ssdt7.dsl    108:                                 {
Error    6126 -                          syntax error ^ 

ACPI/ssdt7.dsl    112:                                 }
Error    6126 -                          syntax error ^ 

Error    6126 -  Compiler aborting due to parser-detected syntax error(s)


ACPI/ssdt7.dsl     49:                 Name (PGCE, Zero)
Remark   2173 -                                ^ Creation of named objects within a method is highly inefficient, use globals or method local variables instead (\SHAD._DSM)

ACPI/ssdt7.dsl     50:                 Name (PGCD, Zero)
Remark   2173 -                                ^ Creation of named objects within a method is highly inefficient, use globals or method local variables instead (\SHAD._DSM)

ACPI/ssdt7.dsl     51:                 Name (PGCG, 0x2E)
Remark   2173 -                                ^ Creation of named objects within a method is highly inefficient, use globals or method local variables instead (\SHAD._DSM)

ACPI/ssdt7.dsl     52:                 Name (DFUE, Zero)
Remark   2173 -                                ^ Creation of named objects within a method is highly inefficient, use globals or method local variables instead (\SHAD._DSM)

ACPI/ssdt7.dsl     53:                 Name (DFUD, Zero)
Remark   2173 -                                ^ Creation of named objects within a method is highly inefficient, use globals or method local variables instead (\SHAD._DSM)

ACPI/ssdt7.dsl     54:                 Name (OLDV, Zero)
Remark   2173 -                                ^ Creation of named objects within a method is highly inefficient, use globals or method local variables instead (\SHAD._DSM)

ACPI/ssdt7.dsl     55:                 Name (PGCV, Zero)
Remark   2173 -                                ^ Creation of named objects within a method is highly inefficient, use globals or method local variables instead (\SHAD._DSM)

ACPI/ssdt7.dsl     56:                 Name (DFUV, Zero)
Remark   2173 -                                ^ Creation of named objects within a method is highly inefficient, use globals or method local variables instead (\SHAD._DSM)

ACPI/ssdt7.dsl     57:                 If ((Arg0 == ToUUID ("03c868d5-563f-42a8-9f57-9a18d949b7cb") /* Unknown UUID */))
Remark   2184 -                                                             Unknown UUID string ^ 

ACPI/ssdt7.dsl     83:                                     Sleep (PGCD)
Remark   2159 -              Very long Sleep, greater than 1 second ^ 

ACPI/ssdt7.dsl     86:                                 }
Error    6126 -                          syntax error ^ 

ACPI/ssdt7.dsl    100:                             Case (0x02)
Error    6126 -                         syntax error ^ 

ACPI/ssdt7.dsl    101:                             {
Error    6126 -                      syntax error ^ 

ACPI/ssdt7.dsl    107:                                 If ((DFUD > Zero))
Error    6126 -                           syntax error ^ 

ACPI/ssdt7.dsl    107:                                 If ((DFUD > Zero))
Error    6114 -      Result is not used, operator has no effect ^ 

ACPI/ssdt7.dsl    108:                                 {
Error    6126 -                          syntax error ^ 

ACPI/ssdt7.dsl    109:                                     Sleep (DFUD)
Remark   2159 -              Very long Sleep, greater than 1 second ^ 

ACPI/ssdt7.dsl    112:                                 }
Error    6126 -                          syntax error ^ 

Input file:    ACPI/ssdt7.dsl - Compilation aborted due to parser-detected syntax error(s)

Compilation failed. 8 Errors, 0 Warnings, 11 Remarks
No AML files were generated due to syntax error(s)
make: *** [Makefile:50: compiled/ssdt7.aml] Error 255
```

</p>
</details>
